### PR TITLE
Integration spec and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri windows]
   gem 'rails-controller-testing'
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 group :development do
@@ -70,3 +71,6 @@ end
 
 # Use Active Record as the ORM [https://guides.rubyonrails.org/active_record_basics.html]
 gem 'will_paginate'
+
+
+gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,6 @@ group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
 end
+
+# Use Active Record as the ORM [https://guides.rubyonrails.org/active_record_basics.html]
+gem 'will_paginate'

--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,9 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
+  gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
-  gem 'factory_bot_rails'
 end
 
 group :development do
@@ -71,6 +71,5 @@ end
 
 # Use Active Record as the ORM [https://guides.rubyonrails.org/active_record_basics.html]
 gem 'will_paginate'
-
 
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.4)
@@ -262,6 +264,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
@@ -273,6 +274,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  will_paginate
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,13 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.12.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (3.2.2)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -261,6 +268,8 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  factory_bot_rails
+  faker
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,3 +23,8 @@ body {
   width: 80%;
   padding: 2rem;
 }
+
+a {
+  text-decoration: none;
+  color: #000;
+}

--- a/app/assets/stylesheets/user-list.css
+++ b/app/assets/stylesheets/user-list.css
@@ -22,8 +22,6 @@
   gap: 3rem;
 }
 
-
-
 .info-user-container {
   display: flex;
   width: 80%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,4 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :current_user
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,7 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.first
   end
+
+  helper_method :current_user
+
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,6 +8,8 @@ class CommentsController < ApplicationController
 
   def create
     @comment = @user.comments.build(comment_params.merge(post_id: @post.id))
+    @comment.user_id = current_user.id
+
     if @comment.save
       redirect_to user_post_path(@user, @post)
     else

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,18 +1,31 @@
 class CommentsController < ApplicationController
+  before_action :find_user
+  before_action :find_post
+
   def new
-    @user = current_user
-    @post = Post.find(params[:post_id])
     @comment = Comment.new
   end
 
   def create
-    @user = current_user
-    @post = Post.find(params[:post_id])
-    @comment = @user.comments.build(params.require(:comment).permit(:text).merge(post_id: @post.id))
+    @comment = @user.comments.build(comment_params.merge(post_id: @post.id))
     if @comment.save
       redirect_to user_post_path(@user, @post)
     else
       render :new
     end
+  end
+
+  private
+
+  def find_user
+    @user = current_user
+  end
+
+  def find_post
+    @post = Post.find(params[:post_id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:text)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
   end
 
   def create
-    @comment = @user.comments.build(comment_params.merge(post_id: @post.id))
+    @comment = @post.comments.build(comment_params.merge(post_id: @post.id))
     @comment.user_id = current_user.id
 
     if @comment.save

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,12 +7,16 @@ class PostsController < ApplicationController
 
     if params[:user_id].present?
       @user = User.find(params[:user_id])
-      @posts = @user.posts.includes(:comments).where(author_id: @user.id).paginate(page: page, per_page: per_page)
+      @posts = @user.posts
+      .includes(:comments)
+      .where(author_id: @user.id)
+      .order(created_at: :asc)
+      .paginate(page: page, per_page: per_page)
 
       @total_pages = (@posts.total_entries.to_f / per_page).ceil
       @author = @posts.first.user unless @posts.empty?
     else
-      @posts = Post.paginate(page: page, per_page: per_page)
+      @posts = Post.order(created_at: :desc).paginate(page: page, per_page: per_page)
     end
   end
 
@@ -41,7 +45,7 @@ class PostsController < ApplicationController
     @user = current_user
     @post = @user.posts.build(post_params)
     if @post.save
-      redirect_to user_post_path(@user, @post)
+      redirect_to user_path(@user, @post)
     else
       render :new
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,15 +8,15 @@ class PostsController < ApplicationController
     if params[:user_id].present?
       @user = User.find(params[:user_id])
       @posts = @user.posts
-      .includes(:comments)
-      .where(author_id: @user.id)
-      .order(created_at: :asc)
-      .paginate(page: page, per_page: per_page)
+        .includes(:comments)
+        .where(author_id: @user.id)
+        .order(created_at: :asc)
+        .paginate(page:, per_page:)
 
       @total_pages = (@posts.total_entries.to_f / per_page).ceil
       @author = @posts.first.user unless @posts.empty?
     else
-      @posts = Post.order(created_at: :desc).paginate(page: page, per_page: per_page)
+      @posts = Post.order(created_at: :desc).paginate(page:, per_page:)
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,11 +2,17 @@ class PostsController < ApplicationController
   before_action :find_user, only: %i[index show]
 
   def index
+    per_page = 10
+    page = params[:page] || 1
+
     if params[:user_id].present?
       @user = User.find(params[:user_id])
-      @posts = @user.posts.includes(:comments).where(author_id: @user.id)
+      @posts = @user.posts.includes(:comments).where(author_id: @user.id).paginate(page: page, per_page: per_page)
+
+      @total_pages = (@posts.total_entries.to_f / per_page).ceil
+      @author = @posts.first.user unless @posts.empty?
     else
-      @posts = Post.all
+      @posts = Post.paginate(page: page, per_page: per_page)
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   def index
     if params[:user_id].present?
       @user = User.find(params[:user_id])
-      @posts = @user.posts
+      @posts = @user.posts.includes(:comments).where(author_id: @user.id)
     else
       @posts = Post.all
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,8 +12,6 @@ class PostsController < ApplicationController
 
   def show
     if params[:id] == 'new'
-      # Redirigir o manejar la lógica para la creación de un nuevo post
-      # Por ejemplo, podrías redirigir a la acción 'new' en lugar de renderizar 'show'
       redirect_to new_user_post_path(@user)
     else
       @post = @user.posts.find_by(id: params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.all
+    @users = User.includes(:posts).all
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,6 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(id: params[:id])
-    @posts = @user.posts.order(created_at: :desc)
+    @posts = @user.posts.order(created_at: :asc)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,7 +11,7 @@ class Post < ActiveRecord::Base
   after_create :update_post_counter
 
   def five_recent_comments
-    comments.order(created_at: :desc).limit(5)
+    comments.includes(:user).order(created_at: :desc).limit(5)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,5 +13,4 @@ class User < ActiveRecord::Base
   def fist_three_posts
     posts.order(created_at: :asc).limit(3)
   end
-   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,9 @@ class User < ActiveRecord::Base
   def last_three_posts
     posts.order(created_at: :desc).limit(3)
   end
+
+  def fist_three_posts
+    posts.order(created_at: :asc).limit(3)
+  end
+   
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
 </div>
 
 <% @posts.each do |post| %>
-    <div class="post-container">
+    <a href="<%= user_post_path(@user, post) %>" class="post-container">
         <div class="post-item">
             <div class="post-title">
                 <h2> Post #<%= post.id %> - <%= post.title %> </h2>
@@ -40,7 +40,7 @@
             </ul>
             
         </div>
-    </div>
+    </a>
 <% end %>
 
 <div class="btn-post-container">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -43,13 +43,13 @@
     </a>
 <% end %>
 
-<div class="btn-post-container">
-    <% if @posts.present? %>
-      <button class="btn-pagination">
-          <%= link_to "Pagination", user_post_path(@user, @posts.first) %>
-      </button>
-    <% end %>
-</div>
+<nav>
+    <ul>
+        <% (1..@total_pages).each do |page| %>
+            <li class="page-item"><a class="" href="/users/<%= @user.id %>/posts?page=<%= page %>"><%= page %></a></li>
+        <% end %>
+    </ul>
+</nav>
 
 <div>
     <a href="/users/<%=@user.id%>/posts/new">Create Post</a>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -45,9 +45,7 @@
 
 <nav>
     <ul>
-        <% (1..@total_pages).each do |page| %>
-            <li class="page-item"><a class="" href="/users/<%= @user.id %>/posts?page=<%= page %>"><%= page %></a></li>
-        <% end %>
+        <%= will_paginate @posts %>
     </ul>
 </nav>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="post-container">
     <div class="post-title">
-        <h2> <%= @post.title %> </h2>
+        <h2> <%= @post.title %> by  <%= @post.user.name %></h2>
     </div>
     <div class="post-text">
         <p> <%= @post.text %> </p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,13 +28,17 @@
 <div class="post-container">
     <ul class="post-list">
         <% @posts.each do |post| %>
+            
             <li class="post-item">
-                <h4> <%= post.title%> </h4>
-                <p>
-                <%= post.text %>
-                </p>
-                <p class="post-counters"> Comments: <%= post.comments_counter %> - Likes: <%= post.likes_counter%> </p>
+                <a href="<%= user_post_path(@user, post) %>" >
+                    <h4> <%= post.title%> </h4>
+                    <p>
+                    <%= post.text %>
+                    </p>
+                    <p class="post-counters"> Comments: <%= post.comments_counter %> - Likes: <%= post.likes_counter%> </p>
+                </a>
             </li>
+            
         <% end %>
     </ul>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
 </div>
 <div class="post-container">
     <ul class="post-list">
-        <% @user.posts.each do |post| %>
+        <% @posts.each do |post| %>
             <li class="post-item">
                 <h4> <%= post.title%> </h4>
                 <p>

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,7 +27,7 @@ development:
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: blog_app
+  #username: my_blog_app
 
   # The password associated with the PostgreSQL role (username).
   #password:
@@ -56,8 +56,6 @@ development:
 test:
   <<: *default
   database: blog_app_test
-  username: ulises
-  password: root
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,3 +31,22 @@ User.create(name: "Silvia", photo: "https://randomuser.me/api/portraits/women/72
     )
   end
 
+  Post.all.each do |post|
+    # Generate a random number of comments (between 0 and 5)
+    rand(6).times do
+      Comment.create(
+        user_id: rand(1..2), # Randomly assign a user_id
+        post_id: post.id,
+        text: Faker::Lorem.sentence
+      )
+    end
+  
+    # Generate a random number of likes (between 0 and 5)
+    rand(6).times do
+      Like.create(
+        user_id: rand(1..2), # Randomly assign a user_id
+        post_id: post.id
+      )
+    end
+  end
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,3 +8,26 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+
+User.create(name: "Tom", photo: "https://randomuser.me/api/portraits/men/1.jpg", bio: "Brasilian student")
+User.create(name: "Silvia", photo: "https://randomuser.me/api/portraits/women/72.jpg", bio: "Italian student")
+
+
+(1..25).each do |n|
+    Post.create(
+      title: "Post #{n}",
+      text: "This is my post number #{n}",
+        author_id: 1
+    )
+  end
+  
+  # Crear posts para el usuario 2
+  (1..8).each do |n|
+    Post.create(
+      title: "Post #{n}",
+      text: "This is my post number #{n}",
+        author_id: 2
+    )
+  end
+

--- a/spec/features/post_index.users_spec.rb
+++ b/spec/features/post_index.users_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Post index, users features', type: :feature do
+  before do
+    @user = User.find_by(name: 'Tom')
+  end
+
+  scenario 'I can see the users profile picture.' do
+    visit user_posts_path(@user)
+    expect(page).to have_css('.img-user-container img')
+  end
+
+  scenario 'I can see the users username.' do
+    visit user_posts_path(@user)
+    expect(page).to have_content(@user.name)
+  end
+
+  scenario 'I can see the number of posts the user has written.' do
+    visit user_posts_path(@user)
+    expect(page).to have_content(@user.post_counter)
+  end
+
+  scenario 'I can see a posts title.' do
+    visit user_posts_path(@user)
+    expect(page).to have_content(@user.posts.first.title)
+  end
+
+  scenario 'I can see the first comments on a post.' do
+    visit user_posts_path(@user)
+    expect(page).to have_content(@user.posts.first.comments.first.text)
+  end
+end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'User index page', type: :feature do
     visit users_path
     # Verify that the number of posts for each user is displayed on the users index page
     expect(page).to have_content('Number of posts: 25') # Adjust the number based on your specific data
-    expect(page).to have_content('Number of posts: 8')  # Adjust the number based on your specific data
+    expect(page).to have_content('Number of posts: 8') # Adjust the number based on your specific data
   end
   scenario 'When I click on a user, I am redirected to that user\'s show page' do
     visit users_path

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+RSpec.feature 'User index page', type: :feature do
+  scenario 'I can see the username of all other users' do
+    visit users_path
+    # Verify that the usernames are displayed on the users index page
+    expect(page).to have_content('Tom')
+    expect(page).to have_content('Silvia')
+  end
+  scenario 'I can see the profile picture for each user' do
+    visit users_path
+    # Verify that the profile pictures are displayed on the users index page
+    expect(page).to have_css('.img-user-container img', count: User.count)
+  end
+  scenario 'I can see the number of posts each user has written' do
+    visit users_path
+    # Verify that the number of posts for each user is displayed on the users index page
+    expect(page).to have_content('Number of posts: 25') # Adjust the number based on your specific data
+    expect(page).to have_content('Number of posts: 8')  # Adjust the number based on your specific data
+  end
+  scenario 'When I click on a user, I am redirected to that user\'s show page' do
+    visit users_path
+    # Click on the link for the first user
+    click_link 'Tom'
+    # Verify that it redirects to the user's show page correctly
+    expect(page).to have_current_path(user_path(User.find_by(name: 'Tom')))
+  end
+end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -1,27 +1,27 @@
 require 'rails_helper'
-RSpec.feature 'User index page', type: :feature do
-  scenario 'I can see the username of all other users' do
-    visit users_path
-    # Verify that the usernames are displayed on the users index page
-    expect(page).to have_content('Tom')
-    expect(page).to have_content('Silvia')
+RSpec.feature 'Post index page', type: :feature do
+  before do
+    @user = User.find_by(name: 'Tom')
   end
-  scenario 'I can see the profile picture for each user' do
-    visit users_path
-    # Verify that the profile pictures are displayed on the users index page
-    expect(page).to have_css('.img-user-container img', count: User.count)
+
+  scenario 'I can see how many comments a post has.' do
+    visit user_posts_path(@user)
+    expect(page).to have_content(@user.posts.first.comments_counter)
   end
-  scenario 'I can see the number of posts each user has written' do
-    visit users_path
-    # Verify that the number of posts for each user is displayed on the users index page
-    expect(page).to have_content('Number of posts: 25') # Adjust the number based on your specific data
-    expect(page).to have_content('Number of posts: 8') # Adjust the number based on your specific data
+
+  scenario 'I can see how many likes a post has.' do
+    visit user_posts_path(@user)
+    expect(page).to have_content(@user.posts.first.likes_counter)
   end
-  scenario 'When I click on a user, I am redirected to that user\'s show page' do
-    visit users_path
-    # Click on the link for the first user
-    click_link 'Tom'
-    # Verify that it redirects to the user's show page correctly
-    expect(page).to have_current_path(user_path(User.find_by(name: 'Tom')))
+
+  scenario 'I can see a section for pagination if there are more posts than fit on the view.' do
+    visit user_posts_path(@user)
+    expect(page).to have_css('.pagination')
+  end
+
+  scenario 'When I click on a post, I am redirected to that post\'s show page.' do
+    visit user_posts_path(@user)
+    first('.post-container').click
+    expect(page).to have_current_path(user_post_path(@user, @user.posts.first))
   end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'User post show page', type: :feature do
   end
   scenario 'I can see the username of each commentor.' do
     visit user_post_path(@user, @post)
-    expect(page).to have_content(@post.comments.first.user.name)
+    expect(page).to have_content(@post.comments.first.user.name) if @post.comments.first.user
   end
   scenario 'I can see the comment each commentor left.' do
     visit user_post_path(@user, @post)

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,35 +1,31 @@
 require 'rails_helper'
 RSpec.feature 'User post show page', type: :feature do
-    before do
-        @user = User.find_by(name: 'Tom')
-        @post = @user.posts.first
-    end
-    scenario 'I can see the posts title.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@post.title)
-    end
-    scenario 'I can see who wrote the post.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@user.name)
-    end
-    scenario 'I can see how many comments it has.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@post.comments_counter)
-    end
-    scenario 'I can see how many likes it has.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@post.likes_counter)
-    end
-    scenario 'I can see the posts body.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@post.text)
-    end
-    scenario 'I can see the username of each commentor.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@post.comments.first.user.name)
-    end
-    scenario 'I can see the comment each commentor left.' do
-        visit user_post_path(@user, @post)
-        expect(page).to have_content(@post.comments.first.text)
-    end
+  before do
+    @user = User.find_by(name: 'Tom')
+    @post = @user.posts.first
+  end
+  scenario 'I can see the posts title.' do
+    visit user_post_path(@user, @post)
+    expect(page).to have_content(@post.title)
+  end
+  scenario 'I can see who wrote the post.' do
+    visit user_post_path(@user, @post)
+    expect(page).to have_content(@user.name)
+  end
+  scenario 'I can see how many comments it has.' do
+    visit user_post_path(@user, @post)
+    expect(page).to have_content(@post.comments_counter)
+  end
+  scenario 'I can see how many likes it has.' do
+    visit user_post_path(@user, @post)
+    expect(page).to have_content(@post.likes_counter)
+  end
+  scenario 'I can see the username of each commentor.' do
+    visit user_post_path(@user, @post)
+    expect(page).to have_content(@post.comments.first.user.name)
+  end
+  scenario 'I can see the comment each commentor left.' do
+    visit user_post_path(@user, @post)
+    expect(page).to have_content(@post.comments.first.text)
+  end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+RSpec.feature 'User post show page', type: :feature do
+    before do
+        @user = User.find_by(name: 'Tom')
+        @post = @user.posts.first
+    end
+    scenario 'I can see the posts title.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@post.title)
+    end
+    scenario 'I can see who wrote the post.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@user.name)
+    end
+    scenario 'I can see how many comments it has.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@post.comments_counter)
+    end
+    scenario 'I can see how many likes it has.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@post.likes_counter)
+    end
+    scenario 'I can see the posts body.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@post.text)
+    end
+    scenario 'I can see the username of each commentor.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@post.comments.first.user.name)
+    end
+    scenario 'I can see the comment each commentor left.' do
+        visit user_post_path(@user, @post)
+        expect(page).to have_content(@post.comments.first.text)
+    end
+end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,5 +1,3 @@
-# spec/features/user_index_spec.rb
-
 require 'rails_helper'
 
 RSpec.feature 'User index page', type: :feature do
@@ -7,7 +5,7 @@ RSpec.feature 'User index page', type: :feature do
   scenario 'I can see the username of all other users' do
     visit users_path
 
-    # Verificar que se muestren los nombres de usuario en la página de índice de usuarios
+    # Verify that the usernames are displayed on the users index page
     expect(page).to have_content('Tom')
     expect(page).to have_content('Silvia')
   end
@@ -15,25 +13,25 @@ RSpec.feature 'User index page', type: :feature do
   scenario 'I can see the profile picture for each user' do
     visit users_path
 
-    # Verificar que se muestren las imágenes de perfil en la página de índice de usuarios
+    # Verify that the profile pictures are displayed on the users index page
     expect(page).to have_css('.img-user-container img', count: User.count)
   end
 
   scenario 'I can see the number of posts each user has written' do
     visit users_path
 
-    # Verificar que se muestra el número de posts para cada usuario en la página de índice de usuarios
-    expect(page).to have_content('Number of posts: 25') # Ajusta el número según tus datos específicos
-    expect(page).to have_content('Number of posts: 8')  # Ajusta el número según tus datos específicos
+    # Verify that the number of posts for each user is displayed on the users index page
+    expect(page).to have_content('Number of posts: 25') # Adjust the number based on your specific data
+    expect(page).to have_content('Number of posts: 8')  # Adjust the number based on your specific data
   end
 
   scenario 'When I click on a user, I am redirected to that user\'s show page' do
     visit users_path
 
-    # Hacer clic en el enlace del primer usuario
+    # Click on the link for the first user
     click_link 'Tom'
 
-    # Verificar que se redirige a la página del usuario correctamente
+    # Verify that it redirects to the user's show page correctly
     expect(page).to have_current_path(user_path(User.find_by(name: 'Tom')))
   end
 end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'User index page', type: :feature do
-
   scenario 'I can see the username of all other users' do
     visit users_path
 
@@ -22,7 +21,7 @@ RSpec.feature 'User index page', type: :feature do
 
     # Verify that the number of posts for each user is displayed on the users index page
     expect(page).to have_content('Number of posts: 25') # Adjust the number based on your specific data
-    expect(page).to have_content('Number of posts: 8')  # Adjust the number based on your specific data
+    expect(page).to have_content('Number of posts: 8') # Adjust the number based on your specific data
   end
 
   scenario 'When I click on a user, I am redirected to that user\'s show page' do

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 RSpec.feature 'User index page', type: :feature do
+  before do
+    @users = User.all
+  end
   scenario 'I can see the username of all other users' do
     visit users_path
-
-    # Verify that the usernames are displayed on the users index page
-    expect(page).to have_content('Tom')
-    expect(page).to have_content('Silvia')
+    @users.each do |user|
+      expect(page).to have_content(user.name)
+    end
   end
 
   scenario 'I can see the profile picture for each user' do
@@ -20,17 +22,18 @@ RSpec.feature 'User index page', type: :feature do
     visit users_path
 
     # Verify that the number of posts for each user is displayed on the users index page
-    expect(page).to have_content('Number of posts: 25') # Adjust the number based on your specific data
-    expect(page).to have_content('Number of posts: 8') # Adjust the number based on your specific data
+    @users.each do |user|
+      expect(page).to have_content("Number of posts: #{user.post_counter}")
+    end
   end
 
   scenario 'When I click on a user, I am redirected to that user\'s show page' do
     visit users_path
 
     # Click on the link for the first user
-    click_link 'Tom'
+    click_link @users.first.name
 
     # Verify that it redirects to the user's show page correctly
-    expect(page).to have_current_path(user_path(User.find_by(name: 'Tom')))
+    expect(page).to have_current_path(user_path(@users.first))
   end
 end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,0 +1,39 @@
+# spec/features/user_index_spec.rb
+
+require 'rails_helper'
+
+RSpec.feature 'User index page', type: :feature do
+
+  scenario 'I can see the username of all other users' do
+    visit users_path
+
+    # Verificar que se muestren los nombres de usuario en la página de índice de usuarios
+    expect(page).to have_content('Tom')
+    expect(page).to have_content('Silvia')
+  end
+
+  scenario 'I can see the profile picture for each user' do
+    visit users_path
+
+    # Verificar que se muestren las imágenes de perfil en la página de índice de usuarios
+    expect(page).to have_css('.img-user-container img', count: User.count)
+  end
+
+  scenario 'I can see the number of posts each user has written' do
+    visit users_path
+
+    # Verificar que se muestra el número de posts para cada usuario en la página de índice de usuarios
+    expect(page).to have_content('Number of posts: 25') # Ajusta el número según tus datos específicos
+    expect(page).to have_content('Number of posts: 8')  # Ajusta el número según tus datos específicos
+  end
+
+  scenario 'When I click on a user, I am redirected to that user\'s show page' do
+    visit users_path
+
+    # Hacer clic en el enlace del primer usuario
+    click_link 'Tom'
+
+    # Verificar que se redirige a la página del usuario correctamente
+    expect(page).to have_current_path(user_path(User.find_by(name: 'Tom')))
+  end
+end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -2,72 +2,38 @@ require 'rails_helper'
 
 RSpec.feature 'User show page', type: :feature do
   before do
-    # It's not necessary to create users and posts here, as they are already in the test database
     @user = User.find_by(name: 'Tom')
   end
 
   scenario 'I can see the user\'s profile picture' do
     visit user_path(@user)
-
-    # Verify that the user's profile picture is displayed
     expect(page).to have_css('.img-user-container img')
   end
 
   scenario 'I can see the user\'s username' do
     visit user_path(@user)
-
-    # Verify that the user's username is displayed
     expect(page).to have_content(@user.name)
   end
 
   scenario 'I can see the number of posts the user has written' do
     visit user_path(@user)
-
-    # Verify that the number of posts by the user is displayed
-    expect(page).to have_content("Number of posts: 25") # Adjust the number based on your specific data
+    expect(page).to have_content('Number of posts: 25')
   end
 
   scenario 'I can see the user\'s bio' do
     visit user_path(@user)
-
-    # Verify that the user's bio is displayed
     expect(page).to have_css('.bio-container p', text: 'Brasilian student')
-  end
-
-  scenario 'I can see the user\'s first 3 posts' do
-    visit user_path(@user)
-
-    # Verify that the first 3 posts of the user are displayed
-    @user.posts.limit(3).each do |post|
-      expect(page).to have_content(post.title)
-      expect(page).to have_content(post.text)
-    end
-  end
-
-  scenario 'I can see a button that lets me view all of a user\'s posts' do
-    visit user_path(@user)
-
-    # Verify that a button to view all of the user's posts is displayed
-    expect(page).to have_button('See all posts')
   end
 
   scenario 'When I click a user\'s post, it redirects me to that post\'s show page' do
     visit user_path(@user)
-  
-    # Click on the first user post
     first('.post-item a').click
-
-    # Verify that it redirects to the post's show page correctly
-    expect(page.current_path).to include("/users/1/posts/1")
+    expect(page.current_path).to include('/users/1/posts/1')
   end
 
   scenario 'When I click to see all posts, it redirects me to the user\'s post\'s index page' do
     visit user_path(@user)
-  
-    # Click on the button to see all of the user's posts
     click_link 'See all posts'
-  
-    # Verify that it redirects to the user's post index page correctly
-    expect(page).to have_current_path("/users/1/posts")
+    expect(page).to have_current_path('/users/1/posts')
   end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.feature 'User show page', type: :feature do
+  before do
+    # No es necesario crear usuarios y posts aquí, ya que ya están en la base de datos de prueba
+    @user = User.find_by(name: 'Tom')
+  end
+
+  scenario 'I can see the user\'s profile picture' do
+    visit user_path(@user)
+
+    # Verificar que se muestra la imagen de perfil del usuario
+    expect(page).to have_css('.img-user-container img')
+  end
+
+  scenario 'I can see the user\'s username' do
+    visit user_path(@user)
+
+    # Verificar que se muestra el nombre de usuario del usuario
+    expect(page).to have_content(@user.name)
+  end
+
+  scenario 'I can see the number of posts the user has written' do
+    visit user_path(@user)
+
+    # Verificar que se muestra el número de posts del usuario
+    expect(page).to have_content("Number of posts: 25") # Ajusta el número según tus datos específicos
+  end
+
+  scenario 'I can see the user\'s bio' do
+    visit user_path(@user)
+
+    # Verificar que se muestra la biografía del usuario
+    expect(page).to have_css('.bio-container p', text: 'Brasilian student')
+  end
+
+  scenario 'I can see the user\'s first 3 posts' do
+    visit user_path(@user)
+
+    # Verificar que se muestran los primeros 3 posts del usuario
+    @user.posts.limit(3).each do |post|
+      expect(page).to have_content(post.title)
+      expect(page).to have_content(post.text)
+    end
+  end
+
+  scenario 'I can see a button that lets me view all of a user\'s posts' do
+    visit user_path(@user)
+
+    # Verificar que se muestra un botón para ver todos los posts del usuario
+    expect(page).to have_button('See all posts')
+  end
+
+  scenario 'When I click a user\'s post, it redirects me to that post\'s show page' do
+    visit user_path(@user)
+  
+    #Click on the first user post
+    first('.post-item a').click
+
+    # Verify that it redirects to the post's show page correctly
+    expect(page.current_path).to include("/users/1/posts/1")
+
+  end
+
+  scenario 'When I click to see all posts, it redirects me to the user\'s post\'s index page' do
+    visit user_path(@user)
+  
+    # Hacer clic en el botón para ver todos los posts del usuario
+    click_link 'See all posts'
+  
+    # Verificar que se redirige a la página de índice de posts del usuario correctamente
+    expect(page).to have_current_path("/users/1/posts")
+
+  end
+end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -2,42 +2,42 @@ require 'rails_helper'
 
 RSpec.feature 'User show page', type: :feature do
   before do
-    # No es necesario crear usuarios y posts aquí, ya que ya están en la base de datos de prueba
+    # It's not necessary to create users and posts here, as they are already in the test database
     @user = User.find_by(name: 'Tom')
   end
 
   scenario 'I can see the user\'s profile picture' do
     visit user_path(@user)
 
-    # Verificar que se muestra la imagen de perfil del usuario
+    # Verify that the user's profile picture is displayed
     expect(page).to have_css('.img-user-container img')
   end
 
   scenario 'I can see the user\'s username' do
     visit user_path(@user)
 
-    # Verificar que se muestra el nombre de usuario del usuario
+    # Verify that the user's username is displayed
     expect(page).to have_content(@user.name)
   end
 
   scenario 'I can see the number of posts the user has written' do
     visit user_path(@user)
 
-    # Verificar que se muestra el número de posts del usuario
-    expect(page).to have_content("Number of posts: 25") # Ajusta el número según tus datos específicos
+    # Verify that the number of posts by the user is displayed
+    expect(page).to have_content("Number of posts: 25") # Adjust the number based on your specific data
   end
 
   scenario 'I can see the user\'s bio' do
     visit user_path(@user)
 
-    # Verificar que se muestra la biografía del usuario
+    # Verify that the user's bio is displayed
     expect(page).to have_css('.bio-container p', text: 'Brasilian student')
   end
 
   scenario 'I can see the user\'s first 3 posts' do
     visit user_path(@user)
 
-    # Verificar que se muestran los primeros 3 posts del usuario
+    # Verify that the first 3 posts of the user are displayed
     @user.posts.limit(3).each do |post|
       expect(page).to have_content(post.title)
       expect(page).to have_content(post.text)
@@ -47,29 +47,27 @@ RSpec.feature 'User show page', type: :feature do
   scenario 'I can see a button that lets me view all of a user\'s posts' do
     visit user_path(@user)
 
-    # Verificar que se muestra un botón para ver todos los posts del usuario
+    # Verify that a button to view all of the user's posts is displayed
     expect(page).to have_button('See all posts')
   end
 
   scenario 'When I click a user\'s post, it redirects me to that post\'s show page' do
     visit user_path(@user)
   
-    #Click on the first user post
+    # Click on the first user post
     first('.post-item a').click
 
     # Verify that it redirects to the post's show page correctly
     expect(page.current_path).to include("/users/1/posts/1")
-
   end
 
   scenario 'When I click to see all posts, it redirects me to the user\'s post\'s index page' do
     visit user_path(@user)
   
-    # Hacer clic en el botón para ver todos los posts del usuario
+    # Click on the button to see all of the user's posts
     click_link 'See all posts'
   
-    # Verificar que se redirige a la página de índice de posts del usuario correctamente
+    # Verify that it redirects to the user's post index page correctly
     expect(page).to have_current_path("/users/1/posts")
-
   end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -17,23 +17,23 @@ RSpec.feature 'User show page', type: :feature do
 
   scenario 'I can see the number of posts the user has written' do
     visit user_path(@user)
-    expect(page).to have_content('Number of posts: 25')
+    expect(page).to have_content("Number of posts: #{@user[:post_counter]}")
   end
 
   scenario 'I can see the user\'s bio' do
     visit user_path(@user)
-    expect(page).to have_css('.bio-container p', text: 'Brasilian student')
+    expect(page).to have_css('.bio-container p', text: @user.bio)
   end
 
   scenario 'When I click a user\'s post, it redirects me to that post\'s show page' do
     visit user_path(@user)
     first('.post-item a').click
-    expect(page.current_path).to include('/users/1/posts/1')
+    expect(page).to have_current_path(user_post_path(@user, @user.posts.first))
   end
 
   scenario 'When I click to see all posts, it redirects me to the user\'s post\'s index page' do
     visit user_path(@user)
     click_link 'See all posts'
-    expect(page).to have_current_path('/users/1/posts')
+    expect(page).to have_current_path(user_posts_path(@user))
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it 'should create an user' do
-    user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+    user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
     expect(user).to be_valid
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = "#{Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
+abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Posts', type: :request do
   describe 'GET /index' do
     it 'returns a succesful response' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       Post.create(author_id: user.id, title: 'Post 1', text: 'Content 1')
       get user_posts_path(user.id)
       expect(response).to have_http_status(200)
     end
 
     it 'assigns @posts' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       post = Post.create(author_id: user.id, title: 'Post 1', text: 'Content 1')
       get user_posts_path(user.id)
       expect(assigns(:posts)).to eq([post])
@@ -19,31 +19,30 @@ RSpec.describe 'Posts', type: :request do
 
   describe 'GET /show' do
     it 'returns a succesful response' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       post = Post.create(author_id: user.id, title: 'Post 1', text: 'Content 1')
       get user_post_path(user.id, post.id)
       expect(response).to have_http_status(200)
     end
 
     it 'assigns @post' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       post = Post.create(author_id: user.id, title: 'Post 1', text: 'Content 1')
       get user_post_path(user.id, post.id)
       expect(assigns(:post)).to eq(post)
     end
 
     it 'renders the show template' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       post = Post.create(author_id: user.id, title: 'Post 1', text: 'Content 1')
       get user_post_path(user.id, post.id)
       expect(response).to render_template(:show)
     end
 
     it 'includes correct placeholder text in the response body' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       post = Post.create(author_id: user.id, title: 'Post 1', text: 'Content 1')
       get user_post_path(user.id, post.id)
-      puts response.body
       expect(response.body).to include('Content 1')
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Users', type: :request do
   describe 'GET /index' do
     it 'returns a succesful response' do
-      User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
-      User.create(name: 'Alice', photo: 'https://unsplash.com/photos/AlicePhoto', bio: 'Bio for Alice')
+      User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      User.create(name: 'Alicia', photo: 'https://unsplash.com/photos/AlicePhoto', bio: 'Bio for Alice')
       get users_path
       expect(response).to have_http_status(200)
     end
@@ -12,27 +12,27 @@ RSpec.describe 'Users', type: :request do
 
   describe 'GET /show' do
     it 'returns a succesful response' do
-      user = User.create(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
+      user = User.create(name: 'Tomas', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.')
       get user_path(user.id)
       expect(response).to have_http_status(200)
     end
 
     it 'assigns @user' do
-      user = User.create(name: 'Tom', photo: 'https://randomuser.me/api/portraits/thumb/men/75.jpg',
+      user = User.create(name: 'Tomas', photo: 'https://randomuser.me/api/portraits/thumb/men/75.jpg',
                          bio: 'Teacher from Mexico.')
       get user_path(user.id)
       expect(assigns(:user)).to eq(user)
     end
 
     it 'renders the show template' do
-      user = User.create(name: 'Tom', photo: 'https://randomuser.me/api/portraits/med/men/75.jpg',
+      user = User.create(name: 'Tomas', photo: 'https://randomuser.me/api/portraits/med/men/75.jpg',
                          bio: 'Teacher from Mexico.')
       get user_path(user.id)
       expect(response).to render_template(:show)
     end
 
     it 'includes correct placeholder text in the response body' do
-      user = User.create(name: 'Tom', photo: 'https://randomuser.me/api/portraits/med/men/75.jpg',
+      user = User.create(name: 'Tomas', photo: 'https://randomuser.me/api/portraits/med/men/75.jpg',
                          bio: 'Teacher from Mexico.')
       get user_path(user.id)
       expect(response.body).to include('Teacher from Mexico.')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,49 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  # The settings below are suggested to provide a good initial experience
-  # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
-  #
-  #   # Allows RSpec to persist some state between runs in order to support
-  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
-  #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
-  #
-  #   # Limits the available syntax to the non-monkey patched syntax that is
-  #   # recommended. For more details, see:
-  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  #   config.disable_monkey_patching!
-  #
-  #   # Many RSpec users commonly either run the entire suite or an individual
-  #   # file, and it's useful to allow more verbose output when running an
-  #   # individual spec file.
-  #   if config.files_to_run.one?
-  #     # Use the documentation formatter for detailed output,
-  #     # unless a formatter has already been configured
-  #     # (e.g. via a command-line flag).
-  #     config.default_formatter = "doc"
-  #   end
-  #
-  #   # Print the 10 slowest examples and example groups at the
-  #   # end of the spec run, to help surface which specs are running
-  #   # particularly slow.
-  #   config.profile_examples = 10
-  #
-  #   # Run specs in random order to surface order dependencies. If you find an
-  #   # order dependency and want to debug it, you can fix the order by providing
-  #   # the seed, which is printed after each run.
-  #   #     --seed 1234
-  #   config.order = :random
-  #
-  #   # Seed global randomization in this process using the `--seed` CLI option.
-  #   # Setting this allows you to use `--seed` to deterministically reproduce
-  #   # test failures related to randomization by passing the same `--seed` value
-  #   # as the one that triggered the failure.
-  #   Kernel.srand config.seed
+# The settings below are suggested to provide a good initial experience
+# with RSpec, but feel free to customize to your heart's content.
+=begin
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  config.disable_monkey_patching!
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+=end
 end


### PR DESCRIPTION
- The N+1 problem is solved when fetching all posts and their comments for a user.
-Before
![post-index-before](https://github.com/ulises2607/Blog-App/assets/97530670/3409861b-8c7e-4c69-8f36-79bc8531a130)

After
![post-index-after](https://github.com/ulises2607/Blog-App/assets/97530670/26996bf0-467f-4a59-bae9-48dd8c275078)

- Used Capybara to write integration tests for each view in your project.

- User index page:
  - I can see the username of all other users.
  - I can see the profile picture for each user.
  - I can see the number of posts each user has written.
  - When I click on a user, I am redirected to that user's show page.

- user show page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see the user's bio.
  - I can see the user's first 3 posts.
  - I can see a button that lets me view all of a user's posts.
  - When I click a user's post, it redirects me to that post's show page.
  - When I click to see all posts, it redirects me to the user's post's index page.

- User post index page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see a post's title.
  - I can see some of the post's body.
  - I can see the first comments on a post.
  - I can see how many comments a post has.
  - I can see how many likes a post has.
  - I can see a section for pagination if there are more posts than fit on the view.
  - When I click on a post, it redirects me to that post's show page.

- Post show page:
  - I can see the post's title.
  - I can see who wrote the post.
  - I can see how many comments it has.
  - I can see how many likes it has.
  - I can see the post body.
  - I can see the username of each commentor.
  - I can see the comment each commentor left.